### PR TITLE
Initial write up of exercises

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The goal of the workshop is to build a continuous deployment pipeline around an 
 
 ## Exercises:
 To start, follow the tasks in the `exercises` directory:
+
 1. [Define a Fastly service with Terraform](exercises/1.md)
 2. [Configure continuous deployment with Travis](exercises/2.md)
 3. [Setup multiple environments: staging & production](exercises/3.md)

--- a/exercises/1.md
+++ b/exercises/1.md
@@ -1,0 +1,157 @@
+## 1. Define a Fastly service with Terraform
+
+### 1.1 main.tf
+Create a file named `main.tf` within the `terraform` directory and edit it using your text editor of choice:
+```sh
+$ touch terraform/main.tf
+```
+> _What's this?_
+A Terraform file `.tf` houses your configurations. Configurations are written in HashiCorp Configuration Language (HCL), which is designed for human consumption so users can quickly interpret and understand their infrastructure configuration. Configuration can be in a single file or split across multiple files.
+
+
+### 1.2 Fastly provider
+In the same Terraform configuration named `main.tf` create Fastly provider definition:
+```hcl
+provider "fastly" {
+  api_key = "<REPLACE WITH YOUR TOKEN>"
+}
+```
+> _What's this?_ 
+A provider is an abstraction of the API/service provider such as AWS, GCP, DNSimple, or Fastly. Providers typically require some sort of configuration data such as an API key or credential file.
+
+
+### 1.3 Fastly resource
+Define a new Fastly service resource block and set the backend to point to the GCS bucket which contains our demo website.
+```hcl
+resource "fastly_service_v1" "service" {
+  name = "<YOUR NEW SERVICE NAME>"
+  force_destroy = false
+}
+```
+
+In the same resource block configure your default domain to be used on your service
+```hcl
+  # Ficitious domain name
+  domain {
+    name    = "<SERVICE NAME>.fastly-altitude-2017.com"
+    comment = "Demo domain"
+  }
+```
+Then define your origin backend. For the purpose of the demo are going to connect to a pre-existing GCS bucket `altitude-nyc-abcd-2017-stage` which hosts the files for our demo website. 
+
+```hcl
+  # GCS backend containing our website files
+  backend {
+    address               = "storage.googleapis.com"
+    ssl_hostname          = "altitude-nyc-abcd-2017-stage.storage.googleapis.com"
+    name                  = "altitude-nyc-abcd-2017-stage"
+    port                  = 443
+    first_byte_timeout    = 3000
+    max_conn              = 200
+    between_bytes_timeout = 1000
+  }
+```
+Finally, our backend requires a header override condition. Just as you can do via the Fastly web UI, we can define the condition as a block within our resource declaration.
+```hcl
+  # Header override condition to 
+  header {
+    name        = "backend-host-override"
+    action      = "set"
+    type        = "request"
+    destination = "http.Host"
+    source      = "\"altitude-nyc-abcd-2017-stage.storage.googleapis.com\""
+  }
+}
+```
+
+Your `main.tf` should now look something like this: 
+```hcl
+provider "fastly" {
+  api_key = "6527a3da0bc7e74d3eec6a9aed654681
+"
+}
+
+resource "fastly_service_v1" "service" {
+  name = "my-altitude-service"
+
+  force_destroy = fasle
+
+  domain {
+    name    = "my-altitude-service.fastly-altitude-2017.com"
+    comment = "Demo domain"
+  }
+
+  backend {
+    address               = "storage.googleapis.com"
+    ssl_hostname          = "altitude-nyc-abcd-2017-stage.storage.googleapis.com"
+    name                  = "altitude-nyc-abcd-2017-stage"
+    port                  = 443
+    first_byte_timeout    = 3000
+    max_conn              = 200
+    between_bytes_timeout = 1000
+  }
+
+  header {
+    name        = "backend-host-override"
+    action      = "set"
+    type        = "request"
+    destination = "http.Host"
+    source      = "\"altitude-nyc-abcd-2017-stage.storage.googleapis.com\""
+  }
+}
+```
+
+### 1.4 Terraform CLI
+Terraform is a local tool (runs on the current machine rather than the cloud) and all interactions with Terraform occur via the CLI. Using the command `terraform`, this binary should have been installed at the install stage of the workshop.
+
+Run `terraform help` to generate the full list of Terraform commands.
+```sh
+$ terraform help
+```
+
+For the purpose of the workshop we will be focusing on the commands `plan` and `apply` to create our Fastly service.
+
+
+### 1.5 Terraform plan
+Now that we've defined our service configuration in our `terraforn/main.tf` file we want to observe what will happen if we were to deploy and apply these changes to our Fastly account. We can do this by running the `terraform plan` CLI command:
+```sh
+$ terraform plan ./terraform
+```
+> _What's this?_ 
+The plan shows you what will happen. You can save plans to guarantee what will happen
+Plans show reasons for certain actions (such as re-create). Prior to Terraform, users had to guess change ordering, parallelization, and rollout effect.
+
+You should see the change graph output in your terminal.
+
+
+### 1.6 Terraform apply
+We should now have confidence after viewing our plan that Terraform is going to create our new Fastly service with the desired configuration. Therefore, all that is left is to apply our changes to Fastly in production. As with `plan`, we can run `terraform apply` on our `main.tf` created in the last section. This will create real resources in Fastly.
+
+```sh
+$ terraform apply ./terraform
+```
+> _What's this?_ 
+Updates existing resources when updates are allowed otherwise re-creates existing resources when updates are not allowed. Changes are executed in order based on the resource graph and parallelizes changes when possible. Handles and recovers transient errors.
+
+You will be able to watch the resources being created in real-time in our terminal. If successful you should see an output such as:
+
+```sh
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+```
+
+
+### 1.7 Celebrate! 🎉
+If your configuration was successfully applied you should be able to `curl` your newly created service:
+```sh 
+$ curl -v http://<YOUR SERVICE DOMAIN>.global.prod.fastly.net/index.html
+
+HTTP/1.1 200 OK
+Cache-Control: public, max-age=3600
+Content-Type: text/html
+Content-Length: 11651
+Connection: keep-alive
+X-Served-By: cache-lcy1136-LCY
+X-Cache: HIT
+X-Cache-Hits: 1
+```
+If you don't believe this you can even login to the Fastly web interface and look at your configuration.

--- a/exercises/2.md
+++ b/exercises/2.md
@@ -1,0 +1,118 @@
+## 2. Configure continuous deployment with Travis
+
+Now that we have defined our Fastly service using Terraform locally, we want to be able to reliably reproduce the infrastruture configuration in a continuous integration environment and deploy our changes to the service every time we check the code into our version control, GitHub. To achieve this, we are going to use the open-source tool [Travis CI](https://travis-ci.org/).
+
+Travis CI provides a hosted build environment and default set of steps to test, build and deploy artefacts. You can customise any step in this process in a `.travis.yml` file in the root of your repository. Travis uses the file to learn about your project and how you want your builds to be executed.
+
+### 2.1 Setup Travis 
+1. Sign in to [Travis CI](https://travis-ci.org/auth) with your GitHub account, accepting the GitHub [access permissions confirmation](https://docs.travis-ci.com/user/github-oauth-scopes).
+
+2. Once you’re signed in, Travis will synchronize your repositories from GitHub, go to your [profile](https://travis-ci.org/profile) page and enable Travis CI for your workshop repository `github.com/<USERNAME>/altitude-nyc-abcd-workshop`.
+
+### 2.2 travis.yml configuration
+Once Travis is configured and authorised for your repository we can add a `.travis.yml` file to tell Travis what actions we'd like it to perform whenever we change our configuration.
+
+Create a file named `.travis.yml` within the root directory of our project and edit it using your text editor of choice:
+```sh
+$ touch .travis.yml
+```
+
+A build on Travis CI is made up of three steps, all of which can be customized using the the yaml declaration format inside our `.travis.yml` file:
+1. `install:` any dependencies required
+2. `script:` run the build script
+3. `deploy:` deploy the artefacts
+
+> _Note:_
+> There are actually more than 3 steps including some optional ones. The complete build lifecycle and hooks and information on how to customize them further can be found [here](https://docs.travis-ci.com/user/customizing-the-build#The-Build-Lifecycle).
+
+Add the following steps to your `.travis.yml` file to customize the build: 
+
+```yml
+# We require the sudo command
+sudo: required
+# Cache the Terraform binary and our local state after each build
+cache:
+- directories:
+  - "$TRAVIS_BUILD_DIR/.state"
+  - "$HOME/terraform"
+# Run make install command to fetch Terraform binary
+install: make install
+# Run Terraform plan
+script: terraform plan -state=./.state ./terraform
+```
+
+### 2.3 Add, commit, push, and build
+To get Travis to trigger our newly defined build in CI we need to add the changed files in our working directory and push them to GitHub. Travis will observe the change to our repository and automatically start a build to run our `install` and `script` commands defined in the `.travis.yml`
+
+```sh
+$ git add -A
+$ git commit -m 'Testing Travis CI'
+$ git push
+```
+
+Wait for Travis CI to run a build on your fork of the `altitude-nyc-abcd-workshop` repository. You can view the output and build status by navigating to: `https://travis-ci.org/<USERNAME>/altitude-nyc-abcd-workshop`
+
+You should have see the output of our `terraform plan` in the job log tab:
+```sh
+TODO
+```
+
+### 2.4 Continuously deploy:
+Now that we have Travis continuously integrating our changes whenever we push changes to our terraform configuration to GitHub, we can use the `deploy:` step inside `.travis.yml` to actually apply our changes to our Fastly service in production.
+
+Add the following declaration the bottom of your `.travis.yml` file:
+
+```yml
+deploy:
+# The deploy will be a simple script command
+- provider: script
+  # don't cleanup the build aretfacts before deployment
+  skip_cleanup: true
+  # run the terraform apply command
+  script: terraform apply -state=./.state ./terraform
+  # only run this deploy step when merging into master
+  on:
+    branch: master
+```
+
+The `script:` declaration is the command that Travis will execute when running the `deploy` step. Here we have simply ran our `terraform apply` command as per the last exercise. Note that we telling Terraform to persist the state to the cached `./state` directory:
+```yml
+  script: terraform apply -state=./.state ./terraform
+```
+
+As we only want to deploy the changes to our service once we are satisfied with them (such as tests passing in the `script` step) and they've been successfully peer reviewed by a colleague via a pull request, we can tell Travis to only deploy the changes on a merge into the `master` branch. This is achieved via the `on:` declaration of the deploy block:
+```yml
+  on:
+    branch: master
+```
+
+To test our deployment we need to make a new branch of our repository and push our changes to the `.travis.yml` file.
+```sh
+$ git checkout -b deployment
+$ git add -A
+$ git commit -m 'Testing Travis CI deployment'
+$ git push origin deployment
+```
+
+Raise a new pull request for the branch changes in GitHub and merge it:
+```sh
+TODO
+```
+
+If you jump over to travis-ci.com you should now be able to watch the build of the `master` branch with our newly added deployment step creating our Fastly service. 
+
+### 2.5 Celebrate! 🎉
+If your configuration was successfully applied via Travis CI you should be able to `curl` your newly created service:
+```sh 
+$ curl -v http://<YOUR SERVICE DOMAIN>.global.prod.fastly.net/index.html
+
+HTTP/1.1 200 OK
+Cache-Control: public, max-age=3600
+Content-Type: text/html
+Content-Length: 11651
+Connection: keep-alive
+X-Served-By: cache-lcy1136-LCY
+X-Cache: HIT
+X-Cache-Hits: 1
+```
+If you don't believe this you can even login to the Fastly web interface and look at your configuration.


### PR DESCRIPTION
Adds the documentation for first two exercises and updates the README.md with installation steps:

- Define a Fastly service with Terraform
- Configure continuous deployment with Travis
